### PR TITLE
Add video stats overlay on video renderer

### DIFF
--- a/Project/src/App.css
+++ b/Project/src/App.css
@@ -290,6 +290,20 @@ ul {
   padding-bottom: 0.5em;
 }
 
+.video-stats {
+  position: absolute;
+  top: 10%;
+  left: 4%;
+  margin-bottom: 0px;
+  background-color: #0000006e;
+  margin: 0.4em;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+  padding: 1em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
 .speaking-border-for-initials > .ms-Persona-coin > .ms-Persona-imageArea > .ms-Persona-initials {
   box-shadow: 0px 0px 0px 3px #ca5010,  0px 0px 20px 5px #ca5010;
 }

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -211,7 +211,7 @@ export default class CallCard extends React.Component {
                         sentResolution = `${data.video.send[0].frameWidthSent}x${data.video.send[0].frameHeightSent}`
                     }
                 }
-                if (this.state.sentResolution != sentResolution) {
+                if (this.state.sentResolution !== sentResolution) {
                     this.setState({ sentResolution });
                 }
                 let stats = {};

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -214,20 +214,24 @@ export default class CallCard extends React.Component {
                 if (this.state.sentResolution != sentResolution) {
                     this.setState({ sentResolution });
                 }
-                let stats = {};
-                if (data?.video?.receive?.length) {
-                    data.video.receive.forEach(v => {
-                        stats[v.streamId] = v;
+                if (this.state.logMediaStats) {
+                    let stats = {};
+                    if (data?.video?.receive?.length) {
+                        data.video.receive.forEach(v => {
+                            stats[v.streamId] = v;
+                        });
+                    } else {
+                        stats = {};
+                    }
+                    this.state.allRemoteParticipantStreams.forEach(v => {
+                        let renderer = v.streamRendererComponentRef.current;
+                        if (stats[v.stream.id]) {
+                            renderer.updateReceiveStats(stats[v.stream.id]);
+                        }
                     });
                 } else {
-                    stats = {};
+
                 }
-                this.state.allRemoteParticipantStreams.forEach(v => {
-                    let renderer = v.streamRendererComponentRef.current;
-                    if (stats[v.stream.id]) {
-                        renderer.updateReceiveStats(stats[v.stream.id]);
-                    }
-                });
             });
             mediaCollector.on('summaryReported', (data) => {
                 if (this.state.logMediaStats) {

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -221,6 +221,11 @@ export default class CallCard extends React.Component {
                             stats[v.streamId] = v;
                         });
                     }
+                    if (data?.screenShare?.receive?.length) {
+                        data.screenShare.receive.forEach(v => {
+                            stats[v.streamId] = v;
+                        });
+                    }
                 }
                 this.state.allRemoteParticipantStreams.forEach(v => {
                     let renderer = v.streamRendererComponentRef.current;

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -214,24 +214,18 @@ export default class CallCard extends React.Component {
                 if (this.state.sentResolution != sentResolution) {
                     this.setState({ sentResolution });
                 }
+                let stats = {};
                 if (this.state.logMediaStats) {
-                    let stats = {};
                     if (data?.video?.receive?.length) {
                         data.video.receive.forEach(v => {
                             stats[v.streamId] = v;
                         });
-                    } else {
-                        stats = {};
                     }
-                    this.state.allRemoteParticipantStreams.forEach(v => {
-                        let renderer = v.streamRendererComponentRef.current;
-                        if (stats[v.stream.id]) {
-                            renderer.updateReceiveStats(stats[v.stream.id]);
-                        }
-                    });
-                } else {
-
                 }
+                this.state.allRemoteParticipantStreams.forEach(v => {
+                    let renderer = v.streamRendererComponentRef.current;
+                    renderer.updateReceiveStats(stats[v.stream.id]);
+                });
             });
             mediaCollector.on('summaryReported', (data) => {
                 if (this.state.logMediaStats) {

--- a/Project/src/MakeCall/StreamRenderer.js
+++ b/Project/src/MakeCall/StreamRenderer.js
@@ -21,7 +21,7 @@ export default class StreamRenderer extends React.Component {
         this.state = {
             isSpeaking: false,
             displayName: this.remoteParticipant.displayName?.trim(),
-            videoStats: null
+            videoStats: undefined
         };
         this.call = props.call;
     }
@@ -123,7 +123,9 @@ export default class StreamRenderer extends React.Component {
     }
 
     updateReceiveStats(videoStats) {
-        this.setState({ videoStats });
+        if (this.state.videoStats !== videoStats) {
+            this.setState({ videoStats });
+        }
     }
 
     async createRenderer() {

--- a/Project/src/MakeCall/StreamRenderer.js
+++ b/Project/src/MakeCall/StreamRenderer.js
@@ -2,6 +2,7 @@ import React from "react";
 import { utils } from '../Utils/Utils';
 import { VideoStreamRenderer } from "@azure/communication-calling";
 import CustomVideoEffects from "./RawVideoAccess/CustomVideoEffects";
+import VideoReceiveStats from './VideoReceiveStats';
 
 export default class StreamRenderer extends React.Component {
     constructor(props) {
@@ -20,6 +21,7 @@ export default class StreamRenderer extends React.Component {
         this.state = {
             isSpeaking: false,
             displayName: this.remoteParticipant.displayName?.trim(),
+            videoStats: null
         };
         this.call = props.call;
     }
@@ -120,6 +122,10 @@ export default class StreamRenderer extends React.Component {
         return this.renderer;
     }
 
+    updateReceiveStats(videoStats) {
+        this.setState({ videoStats });
+    }
+
     async createRenderer() {
         console.info(`[App][StreamMedia][id=${this.stream.id}][renderStream] attempt to render stream type=${this.stream.mediaStreamType}, id=${this.stream.id}`);
         if (!this.renderer) {
@@ -161,6 +167,12 @@ export default class StreamRenderer extends React.Component {
                     <h4 className="video-title">
                         {this.state.displayName ? this.state.displayName : utils.getIdentifierText(this.remoteParticipant.identifier)}
                     </h4>
+                    {
+                        this.state.videoStats &&
+                        <h4 className="video-stats">
+                            <VideoReceiveStats videoStats={this.state.videoStats} />
+                        </h4>
+                    }
                 </div>
                 <CustomVideoEffects call={this.call} videoContainerId={this.videoContainerId} remoteParticipantId={this.remoteParticipant.identifier}/>
             </div>

--- a/Project/src/MakeCall/VideoReceiveStats.js
+++ b/Project/src/MakeCall/VideoReceiveStats.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+export default class VideoReceiveStats extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            this.props.videoStats &&
+            <table>
+                <tbody>
+                    <tr>
+                        <td>codec:</td>
+                        <td>{this.props.videoStats.codecName}</td>
+                    </tr>
+                    <tr>
+                        <td>bitrate:</td>
+                        <td>{(this.props.videoStats.bitrate/1000).toFixed(1)} kbps</td>
+                    </tr>
+                    <tr>
+                        <td>jitter:</td>
+                        <td>{this.props.videoStats.jitterInMs} ms</td>
+                    </tr>
+                    <tr>
+                        <td>rtt:</td>
+                        <td>{this.props.videoStats.pairRttInMs} ms</td>
+                    </tr>
+                    <tr>
+                        <td>packetsPerSecond:</td>
+                        <td>{this.props.videoStats.packetsPerSecond}</td>
+                    </tr>
+                    <tr>
+                        <td>frameWidthReceived:</td>
+                        <td>{this.props.videoStats.frameWidthReceived} px</td>
+                    </tr>
+                    <tr>
+                        <td>frameHeightReceived:</td>
+                        <td>{this.props.videoStats.frameHeightReceived} px</td>
+                    </tr>
+                    <tr>
+                        <td>frameRateDecoded:</td>
+                        <td>{this.props.videoStats.frameRateDecoded} fps</td>
+                    </tr>
+                    <tr>
+                        <td>frameRateReceived:</td>
+                        <td>{this.props.videoStats.frameRateReceived} fps</td>
+                    </tr>
+                    <tr>
+                        <td>framesReceived:</td>
+                        <td>{this.props.videoStats.framesReceived}</td>
+                    </tr>
+                    <tr>
+                        <td>framesDropped:</td>
+                        <td>{this.props.videoStats.framesDropped}</td>
+                    </tr>
+                    <tr>
+                        <td>framesDecoded:</td>
+                        <td>{this.props.videoStats.framesDecoded}</td>
+                    </tr>
+                </tbody>
+            </table>
+        );
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fix mediastats log switch button 
* Add video stream stats overlay on video renderer when mediastats log switch is on

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* click the right most button on CallCard, we should see an overlay showing mediastats on video renderer, also see mediastats in console log every second.

## Other Information
<!-- Add any other helpful information that may be needed here. -->