### PR TITLE
Add video stats overlay on video renderer

### DIFF
--- a/Project/src/App.css
+++ b/Project/src/App.css
@@ -266,6 +266,20 @@ ul {
   padding-bottom: 0.5em;
 }
 
+.video-stats {
+  position: absolute;
+  top: 10%;
+  left: 4%;
+  margin-bottom: 0px;
+  background-color: #0000006e;
+  margin: 0.4em;
+  margin-left: 0.5em;
+  margin-right: 0.5em;
+  padding: 1em;
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
 .speaking-border-for-initials > .ms-Persona-coin > .ms-Persona-imageArea > .ms-Persona-initials {
   box-shadow: 0px 0px 0px 3px #ca5010,  0px 0px 20px 5px #ca5010;
 }

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -230,7 +230,7 @@ export default class CallCard extends React.Component {
                         sentResolution = `${data.video.send[0].frameWidthSent}x${data.video.send[0].frameHeightSent}`
                     }
                 }
-                if (this.state.sentResolution != sentResolution) {
+                if (this.state.sentResolution !== sentResolution) {
                     this.setState({ sentResolution });
                 }
                 let stats = {};

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -240,6 +240,11 @@ export default class CallCard extends React.Component {
                             stats[v.streamId] = v;
                         });
                     }
+                    if (data?.screenShare?.receive?.length) {
+                        data.screenShare.receive.forEach(v => {
+                            stats[v.streamId] = v;
+                        });
+                    }
                 }
                 this.state.allRemoteParticipantStreams.forEach(v => {
                     let renderer = v.streamRendererComponentRef.current;

--- a/Project/src/MakeCall/StreamRenderer.js
+++ b/Project/src/MakeCall/StreamRenderer.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { utils } from '../Utils/Utils';
 import { VideoStreamRenderer } from "@azure/communication-calling";
+import VideoReceiveStats from './VideoReceiveStats';
 export default class StreamRenderer extends React.Component {
     constructor(props) {
         super(props);
@@ -18,6 +19,7 @@ export default class StreamRenderer extends React.Component {
         this.state = {
             isSpeaking: false,
             displayName: this.remoteParticipant.displayName?.trim(),
+            videoStats: undefined,
         };
     }
 
@@ -117,6 +119,12 @@ export default class StreamRenderer extends React.Component {
         return this.renderer;
     }
 
+    updateReceiveStats(videoStats) {
+        if (this.state.videoStats !== videoStats) {
+            this.setState({ videoStats });
+        }
+    }
+
     async createRenderer() {
         console.info(`[App][StreamMedia][id=${this.stream.id}][renderStream] attempt to render stream type=${this.stream.mediaStreamType}, id=${this.stream.id}`);
         if (!this.renderer) {
@@ -158,6 +166,12 @@ export default class StreamRenderer extends React.Component {
                     <h4 className="video-title">
                         {this.state.displayName ? this.state.displayName : utils.getIdentifierText(this.remoteParticipant.identifier)}
                     </h4>
+                    {
+                        this.state.videoStats &&
+                        <h4 className="video-stats">
+                            <VideoReceiveStats videoStats={this.state.videoStats} />
+                        </h4>
+                    }
                 </div>
             </div>
         );

--- a/Project/src/MakeCall/VideoReceiveStats.js
+++ b/Project/src/MakeCall/VideoReceiveStats.js
@@ -1,0 +1,65 @@
+import React from "react";
+
+export default class VideoReceiveStats extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    render() {
+        return (
+            this.props.videoStats &&
+            <table>
+                <tbody>
+                    <tr>
+                        <td>codec:</td>
+                        <td>{this.props.videoStats.codecName}</td>
+                    </tr>
+                    <tr>
+                        <td>bitrate:</td>
+                        <td>{(this.props.videoStats.bitrate/1000).toFixed(1)} kbps</td>
+                    </tr>
+                    <tr>
+                        <td>jitter:</td>
+                        <td>{this.props.videoStats.jitterInMs} ms</td>
+                    </tr>
+                    <tr>
+                        <td>rtt:</td>
+                        <td>{this.props.videoStats.pairRttInMs} ms</td>
+                    </tr>
+                    <tr>
+                        <td>packetsPerSecond:</td>
+                        <td>{this.props.videoStats.packetsPerSecond}</td>
+                    </tr>
+                    <tr>
+                        <td>frameWidthReceived:</td>
+                        <td>{this.props.videoStats.frameWidthReceived} px</td>
+                    </tr>
+                    <tr>
+                        <td>frameHeightReceived:</td>
+                        <td>{this.props.videoStats.frameHeightReceived} px</td>
+                    </tr>
+                    <tr>
+                        <td>frameRateDecoded:</td>
+                        <td>{this.props.videoStats.frameRateDecoded} fps</td>
+                    </tr>
+                    <tr>
+                        <td>frameRateReceived:</td>
+                        <td>{this.props.videoStats.frameRateReceived} fps</td>
+                    </tr>
+                    <tr>
+                        <td>framesReceived:</td>
+                        <td>{this.props.videoStats.framesReceived}</td>
+                    </tr>
+                    <tr>
+                        <td>framesDropped:</td>
+                        <td>{this.props.videoStats.framesDropped}</td>
+                    </tr>
+                    <tr>
+                        <td>framesDecoded:</td>
+                        <td>{this.props.videoStats.framesDecoded}</td>
+                    </tr>
+                </tbody>
+            </table>
+        );
+    }
+}


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Add video stats overlay on video renderer

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* click the mediastats log switch button, the video stats overlay will show on top of video renderer.

## Other Information
<!-- Add any other helpful information that may be needed here. -->