### PR TITLE
Capability applied for Reaction API usage

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -1,7 +1,5 @@
 import React from "react";
-import { MessageBar, MessageBarType, DefaultButton } from 'office-ui-fabric-react'
-import { Toggle } from '@fluentui/react/lib/Toggle';
-import { TooltipHost } from '@fluentui/react/lib/Tooltip';
+import { MessageBar, MessageBarType } from 'office-ui-fabric-react'
 import { FunctionalStreamRenderer as StreamRenderer } from "./FunctionalStreamRenderer";
 import AddParticipantPopover from "./AddParticipantPopover";
 import RemoteParticipantCard from "./RemoteParticipantCard";
@@ -9,7 +7,7 @@ import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
 import { Icon } from '@fluentui/react/lib/Icon';
 import LocalVideoPreviewCard from './LocalVideoPreviewCard';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
-import { LocalVideoStream, Features, LocalAudioStream, VideoStreamRenderer, CallKind } from '@azure/communication-calling';
+import { LocalVideoStream, Features, LocalAudioStream } from '@azure/communication-calling';
 import { utils } from '../Utils/Utils';
 import CustomVideoEffects from "./RawVideoAccess/CustomVideoEffects";
 import VideoEffectsContainer from './VideoEffects/VideoEffectsContainer';

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -648,9 +648,13 @@ export default class CallCard extends React.Component {
         
         if(!this.state.canReact) {
             // 1:1 direct call with teams user is not supported.
-            messageBarText = 'Reaction capability is not allowed for this call type';
+            const messageBarText = 'Reaction capability is not allowed for this call type';
             console.error(messageBarText);
-            this.setState({ callMessage: messageBarText })
+            this.setState(prevState => ({
+                ...prevState,
+                callMessage: `${prevState.callMessage ? prevState.callMessage + `\n` : ``}
+                                ${messageBarText}. \n`
+            }));
             return ;
         }
 
@@ -682,8 +686,12 @@ export default class CallCard extends React.Component {
         } catch (error) {
             // Surface the error 
             console.error(error);
-            messageBarText = JSON.stringify(error);
-            this.setState({ callMessage: messageBarText })
+            const messageBarText = JSON.stringify(error);
+            this.setState(prevState => ({
+                ...prevState,
+                callMessage: `${prevState.callMessage ? prevState.callMessage + `\n` : ``}
+                                ${messageBarText}. \n`
+            }));
         }
     }
 

--- a/Project/src/MakeCall/MakeCall.js
+++ b/Project/src/MakeCall/MakeCall.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { CallClient, LocalVideoStream, Features, CallAgentKind, VideoStreamRenderer } from '@azure/communication-calling';
+import { CallClient, LocalVideoStream, Features, CallAgentKind, VideoStreamRenderer, IncomingCallKind } from '@azure/communication-calling';
 import { AzureCommunicationTokenCredential, createIdentifierFromRawId} from '@azure/communication-common';
 import {
     PrimaryButton,
@@ -63,7 +63,8 @@ export default class MakeCall extends React.Component {
             },
             preCallDiagnosticsResults: {},
             isTeamsUser: false,
-            identityMri: undefined
+            identityMri: undefined,
+            callJoinType: null
         };
 
         setInterval(() => {
@@ -164,6 +165,13 @@ export default class MakeCall extends React.Component {
                     if (this.state.call) {
                         incomingCall.reject();
                         return;
+                    }
+
+                    if(incomingCall.kind === IncomingCallKind.IncomingCall) {
+                        this.setState({callJoinType: CallJoinType.AcsCall});
+                    }
+                    if(incomingCall.kind === IncomingCallKind.TeamsIncomingCall) {
+                        this.setState({callJoinType: CallJoinType.TeamsCall});
                     }
 
                     this.setState({ incomingCall: incomingCall });
@@ -291,6 +299,7 @@ export default class MakeCall extends React.Component {
         try {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             this.callAgent.join({ groupId: this.destinationGroup.value }, callOptions);
+            this.setState({callJoinType: CallJoinType.AcsCall});
         } catch (e) {
             console.error('Failed to join a call', e);
             this.setState({ callError: 'Failed to join a call: ' + e });
@@ -301,6 +310,7 @@ export default class MakeCall extends React.Component {
         try {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             this.callAgent.join({ roomId: this.roomsId.value }, callOptions);
+            this.setState({callJoinType: CallJoinType.RoomsCall});
         } catch (e) {
             console.error('Failed to join a call', e);
             this.setState({ callError: 'Failed to join a call: ' + e });
@@ -312,12 +322,13 @@ export default class MakeCall extends React.Component {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             if (this.meetingLink.value && !this.messageId.value && !this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({ meetingLink: this.meetingLink.value }, callOptions);
-
+                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else if (this.meetingId.value  || this.passcode.value && !this.meetingLink.value && !this.messageId.value && !this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({ 
                     meetingId: this.meetingId.value,
                     passcode: this.passcode.value 
                 }, callOptions);
+                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else if (!this.meetingLink.value && this.messageId.value && this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({
                     messageId: this.messageId.value,
@@ -325,6 +336,7 @@ export default class MakeCall extends React.Component {
                     tenantId: this.tenantId.value,
                     organizerId: this.organizerId.value
                 }, callOptions);
+                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else {
                 throw new Error('Please enter Teams meeting link or Teams meeting coordinate');
             }
@@ -1040,9 +1052,10 @@ this.deviceManager.on('selectedSpeakerChanged', () => { console.log(this.deviceM
                             </div>
                         }
                         {
-                            this.state.call && !this.state.callSurvey && !this.state.isPreCallDiagnosticsCallInProgress &&
+                            this.state.call && this.state.callJoinType && !this.state.callSurvey && !this.state.isPreCallDiagnosticsCallInProgress &&
                             <CallCard
                                 call={this.state.call}
+                                callJoinType={this.state.callJoinType}
                                 deviceManager={this.deviceManager}
                                 selectedCameraDeviceId={this.state.selectedCameraDeviceId}
                                 cameraDeviceOptions={this.state.cameraDeviceOptions}
@@ -1336,3 +1349,9 @@ this.deviceManager.on('selectedSpeakerChanged', () => { console.log(this.deviceM
         );
     }
 }
+
+export const CallJoinType = Object.freeze({
+    TeamsCall: 'TeamsCall',
+    AcsCall: 'AcsCall',
+    RoomsCall: 'RoomsCall'
+});

--- a/Project/src/MakeCall/MakeCall.js
+++ b/Project/src/MakeCall/MakeCall.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { CallClient, LocalVideoStream, Features, CallAgentKind, VideoStreamRenderer, IncomingCallKind } from '@azure/communication-calling';
+import { CallClient, LocalVideoStream, Features, CallAgentKind, VideoStreamRenderer } from '@azure/communication-calling';
 import { AzureCommunicationTokenCredential, createIdentifierFromRawId} from '@azure/communication-common';
 import {
     PrimaryButton,

--- a/Project/src/MakeCall/MakeCall.js
+++ b/Project/src/MakeCall/MakeCall.js
@@ -63,8 +63,7 @@ export default class MakeCall extends React.Component {
             },
             preCallDiagnosticsResults: {},
             isTeamsUser: false,
-            identityMri: undefined,
-            callJoinType: null
+            identityMri: undefined
         };
 
         setInterval(() => {
@@ -165,13 +164,6 @@ export default class MakeCall extends React.Component {
                     if (this.state.call) {
                         incomingCall.reject();
                         return;
-                    }
-
-                    if(incomingCall.kind === IncomingCallKind.IncomingCall) {
-                        this.setState({callJoinType: CallJoinType.AcsCall});
-                    }
-                    if(incomingCall.kind === IncomingCallKind.TeamsIncomingCall) {
-                        this.setState({callJoinType: CallJoinType.TeamsCall});
                     }
 
                     this.setState({ incomingCall: incomingCall });
@@ -299,7 +291,6 @@ export default class MakeCall extends React.Component {
         try {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             this.callAgent.join({ groupId: this.destinationGroup.value }, callOptions);
-            this.setState({callJoinType: CallJoinType.AcsCall});
         } catch (e) {
             console.error('Failed to join a call', e);
             this.setState({ callError: 'Failed to join a call: ' + e });
@@ -310,7 +301,6 @@ export default class MakeCall extends React.Component {
         try {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             this.callAgent.join({ roomId: this.roomsId.value }, callOptions);
-            this.setState({callJoinType: CallJoinType.RoomsCall});
         } catch (e) {
             console.error('Failed to join a call', e);
             this.setState({ callError: 'Failed to join a call: ' + e });
@@ -322,13 +312,11 @@ export default class MakeCall extends React.Component {
             const callOptions = await this.getCallOptions({video: withVideo, micMuted: false});
             if (this.meetingLink.value && !this.messageId.value && !this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({ meetingLink: this.meetingLink.value }, callOptions);
-                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else if (this.meetingId.value  || this.passcode.value && !this.meetingLink.value && !this.messageId.value && !this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({ 
                     meetingId: this.meetingId.value,
                     passcode: this.passcode.value 
                 }, callOptions);
-                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else if (!this.meetingLink.value && this.messageId.value && this.threadId.value && this.tenantId && this.organizerId) {
                 this.callAgent.join({
                     messageId: this.messageId.value,
@@ -336,7 +324,6 @@ export default class MakeCall extends React.Component {
                     tenantId: this.tenantId.value,
                     organizerId: this.organizerId.value
                 }, callOptions);
-                this.setState({callJoinType: CallJoinType.TeamsCall});
             } else {
                 throw new Error('Please enter Teams meeting link or Teams meeting coordinate');
             }
@@ -1052,10 +1039,9 @@ this.deviceManager.on('selectedSpeakerChanged', () => { console.log(this.deviceM
                             </div>
                         }
                         {
-                            this.state.call && this.state.callJoinType && !this.state.callSurvey && !this.state.isPreCallDiagnosticsCallInProgress &&
+                            this.state.call && !this.state.callSurvey && !this.state.isPreCallDiagnosticsCallInProgress &&
                             <CallCard
                                 call={this.state.call}
-                                callJoinType={this.state.callJoinType}
                                 deviceManager={this.deviceManager}
                                 selectedCameraDeviceId={this.state.selectedCameraDeviceId}
                                 cameraDeviceOptions={this.state.cameraDeviceOptions}
@@ -1349,9 +1335,3 @@ this.deviceManager.on('selectedSpeakerChanged', () => { console.log(this.deviceM
         );
     }
 }
-
-export const CallJoinType = Object.freeze({
-    TeamsCall: 'TeamsCall',
-    AcsCall: 'AcsCall',
-    RoomsCall: 'RoomsCall'
-});


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Capability read for reaction applied in the API usage for reaction API
* For not allowed scenario - the API usage would return an error 

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* Check for below error message when reaction button is tapped but not allowed in meeting.
<img width="1688" alt="Screenshot 2023-11-01 at 8 01 55 PM" src="https://github.com/Azure-Samples/communication-services-web-calling-tutorial/assets/99507832/7d77ed01-f230-4fd1-99fd-9ddc771a5297">



## Other Information
<!-- Add any other helpful information that may be needed here. -->