### PR TITLE
Make thread ID parameter as optional when placing a CTE group call

### DIFF
--- a/Project/src/MakeCall/MakeCall.js
+++ b/Project/src/MakeCall/MakeCall.js
@@ -243,9 +243,7 @@ export default class MakeCall extends React.Component {
             }
 
             if (identitiesToCall.length > 1) {
-                if (this.callAgent.kind === CallAgentKind.TeamsCallAgent && this.threadId === '') {
-                    throw new Error('Thread ID is needed to make Teams Group Call');
-                } else {
+                if (this.callAgent.kind === CallAgentKind.TeamsCallAgent && this.threadId?.value !== '') {
                     callOptions.threadId = this.threadId.value;
                 }
             }


### PR DESCRIPTION
## Purpose
With new coming feature of thread ID integration on web calling SDK, Contoso App can leverage API to place a CTE group call without providing thread ID. So we do the corresponding change on public sample as well to allow user place a CTE group call without passing on thread ID.

## Does this introduce a breaking change?
```
[ ] Yes
[X] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[X] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...
