### PR TITLE
HIde captions button when not connected to a call

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -1289,6 +1289,7 @@ export default class CallCard extends React.Component {
                         <span className="in-call-button"
                             title={`${this.state.captionOn ? 'Turn captions off' : 'Turn captions on'}`}
                             variant="secondary"
+                            hidden={this.state.callState !== 'Connected'}
                             onClick={() => { this.setState({ captionOn: !this.state.captionOn })}}>
                             {
                                 this.state.captionOn &&


### PR DESCRIPTION
Hide captions button when not connected to a call. 
Adding captions bot participant is only possible once user is connected to the call.