### PR TITLE
Add muteOthers capability to Call and RemoteParticipant

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -64,6 +64,7 @@ export default class CallCard extends React.Component {
             canShareScreen: this.capabilities.shareScreen?.isPresent || this.capabilities.shareScreen?.reason === 'FeatureNotSupported',
             canRaiseHands: this.capabilities.raiseHand?.isPresent || this.capabilities.raiseHand?.reason === 'FeatureNotSupported',
             canSpotlight: this.capabilities.spotlightParticipant?.isPresent || this.capabilities.spotlightParticipant?.reason === 'FeatureNotSupported',
+            canMuteOthers: this.capabilities.muteOthers?.isPresent || this.capabilities.muteOthers?.reason === 'FeatureNotSupported',
             canReact: this.capabilities.useReactions?.isPresent || this.capabilities.useReactions?.reason === 'FeatureNotSupported',
             videoOn: this.call.isLocalVideoStarted,
             screenSharingOn: this.call.isScreenSharingOn,
@@ -610,6 +611,10 @@ export default class CallCard extends React.Component {
             }
             if(key === 'raiseHand' && value.reason != 'FeatureNotSupported') {
                 (value.isPresent) ? this.setState({ canRaiseHands: true }) : this.setState({ canRaiseHands: false });
+                continue;
+            }
+            if(key === 'muteOthers' && value.reason != 'FeatureNotSupported') {
+                (value.isPresent) ? this.setState({ canMuteOthers: true }) : this.setState({ canMuteOthers: false });
                 continue;
             }
             if(key === 'reaction' && value.reason != 'FeatureNotSupported') {
@@ -1319,12 +1324,15 @@ export default class CallCard extends React.Component {
                                 <Icon iconName="Volume2" />
                             }
                         </span>
-                        <span className="in-call-button"
-                            title={`Mute all other participants`}
-                            variant="secondary"
-                            onClick={() => this.handleMuteAllRemoteParticipants()}>
-                            <Icon iconName="VolumeDisabled" />
-                        </span>
+                        {
+                            this.state.canMuteOthers &&
+                            <span className="in-call-button"
+                                title={`Mute all other participants`}
+                                variant="secondary"
+                                onClick={() => this.handleMuteAllRemoteParticipants()}>
+                                <Icon iconName="VolumeDisabled" />
+                            </span>
+                        }
                         <span className="in-call-button"
                             title={`${this.state.screenSharingOn && this.localScreenSharingStream?.mediaStreamType === 'RawMedia' ? 'Stop' : 'Start'} screen sharing a dummy stream`}
                             variant="secondary"

--- a/Project/src/MakeCall/RemoteParticipantCard.js
+++ b/Project/src/MakeCall/RemoteParticipantCard.js
@@ -35,6 +35,7 @@ export default class RemoteParticipantCard extends React.Component {
             isHandRaised: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.raiseHandFeature.getRaisedHands()),
             isSpotlighted: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.spotlightFeature.getSpotlightedParticipants()),
             canManageLobby: this.capabilities.manageLobby?.isPresent || this.capabilities.manageLobby?.reason === 'FeatureNotSupported',
+            canMuteOthers: this.capabilities.muteOthers?.isPresent || this.capabilities.muteOthers?.reason === 'FeatureNotSupported',
         };
     }
 
@@ -108,7 +109,11 @@ export default class RemoteParticipantCard extends React.Component {
 
     handleMuteParticipant(e, remoteParticipant) {
         e.preventDefault();
-        remoteParticipant.mute?.().catch((e) => console.error('Failed to mute specific participant.', e))
+        if (this.state.canMuteOthers) {
+            remoteParticipant.mute?.().catch((e) => console.error('Failed to mute specific participant.', e.message, e));
+        } else {
+            console.error('Soft mute of remote participants is not a supported capability for this participant.');
+        }
     }
 
     handleCheckboxChange(e) {


### PR DESCRIPTION
## Purpose
* Blocks Mute All button from appearing if user does not have the capability to muteOthers
* Logs console error from clicking on mute icon of remote participant if user does not have the capability to muteOthers

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
1. Login in 2 tabs as ACS users 
1. Create a Room with 1 user as Presenter, 1 user as Attendee

## What to Check
Verify that the following are valid
1. Presenter has Mute All button, can mute all successfully. Presenter can mute specific remote participant successfully. 
1. Attendee does not have Mute All button. Attendee cannot mute specific remote participant. 

## Other Information
<!-- Add any other helpful information that may be needed here. -->