### PR TITLE
Fix lobby admitall button and lobby participants count

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -131,7 +131,7 @@ export default class CallCard extends React.Component {
         this.call.feature(Features.RaiseHand).off('loweredHandEvent', this.raiseHandChangedHandler);
         this.recordingFeature.off('isRecordingActiveChanged', this.isRecordingActiveChangedHandler);
         this.transcriptionFeature.off('isTranscriptionActiveChanged', this.isTranscriptionActiveChangedHandler);
-        this.call.lobby?.off('lobbyParticipantsUpdated', () => { });
+        this.lobby?.off('lobbyParticipantsUpdated', () => { });
         if (Features.Reaction) {
             this.call.feature(Features.Reaction).off('reaction', this.reactionChangeHandler);
         }

--- a/Project/src/MakeCall/Lobby.js
+++ b/Project/src/MakeCall/Lobby.js
@@ -8,38 +8,23 @@ export default class Lobby extends React.Component {
         super(props);
         this.call = props.call;
         this.lobby = this.call.lobby;
-        
         this.capabilitiesFeature = props.capabilitiesFeature;
         this.capabilities = this.capabilitiesFeature.capabilities;
         this.state = {
             canManageLobby: this.capabilities.manageLobby?.isPresent || this.capabilities.manageLobby?.reason === 'FeatureNotSupported',
-            lobbyParticipantsCount: this.lobby.participants.length
+            lobbyParticipantsCount: props.lobbyParticipantsCount
         };
     }
 
-    componentWillUnmount() {
-        this.lobby?.off('lobbyParticipantsUpdated', () => { });
-    }
-
     componentDidMount() {
-        this.lobby?.on('lobbyParticipantsUpdated', this.lobbyParticipantsUpdatedHandler);
         this.capabilitiesFeature.on('capabilitiesChanged', this.capabilitiesChangedHandler);
     }
 
-    lobbyParticipantsUpdatedHandler = (event) => {
-        console.log(`lobbyParticipantsUpdated, added=${event.added}, removed=${event.removed}`);
-        this.state.lobbyParticipantsCount = this.lobby?.participants.length;
-        if(event.added.length > 0) {
-            event.added.forEach(participant => {
-                console.log('lobbyParticipantAdded', participant);
-            });
+    componentWillReceiveProps(nextProps) {
+        if (nextProps.lobbyParticipantsCount !== this.state.lobbyParticipantsCount) {
+            this.setState({ lobbyParticipantsCount: nextProps.lobbyParticipantsCount });
         }
-        if(event.removed.length > 0) {
-            event.removed.forEach(participant => {
-                console.log('lobbyParticipantRemoved', participant);
-            });
-        }
-    };
+    }
 
     capabilitiesChangedHandler = (capabilitiesChangeInfo) => {
         console.log('lobby:capabilitiesChanged');
@@ -68,24 +53,19 @@ export default class Lobby extends React.Component {
 
     render() {
         return (
-            <div>
-                {
-                    (this.state.lobbyParticipantsCount > 0) &&
-                    <div className="ms-Grid-row">
-                        <div className="ml-2 inline-block">
-                            <div>In-Lobby participants number: {this.state.lobbyParticipantsCount}</div>
-                        </div>
-                        <div className="ml-4 inline-block">
-                            <PrimaryButton className="primary-button"
-                                            id="admitAllButton"
-                                            style={{ display: this.state.canManageLobby ? '' : 'none' }}
-                                            iconProps={{ iconName: 'Group', style: { verticalAlign: 'middle', fontSize: 'large' } }}
-                                            text="Admit All Participants"
-                                            onClick={() => this.admitAllParticipants()}>
-                            </PrimaryButton>
-                        </div>
-                    </div>
-                }
+            <div className="ms-Grid-row">
+                <div className="ml-2 inline-block">
+                    <div>In-Lobby participants number: {this.state.lobbyParticipantsCount}</div>
+                </div>
+                <div className="ml-4 inline-block">
+                    <PrimaryButton className="primary-button"
+                                    id="admitAllButton"
+                                    style={{ display: this.state.canManageLobby ? '' : 'none' }}
+                                    iconProps={{ iconName: 'Group', style: { verticalAlign: 'middle', fontSize: 'large' } }}
+                                    text="Admit All Participants"
+                                    onClick={() => this.admitAllParticipants()}>
+                    </PrimaryButton>
+                </div>
             </div>
         );
     }


### PR DESCRIPTION
## Purpose
Fix the bug: [In-lobby participant count and "Admit all participants" button stays visible after all in-lobby participants have already been admitted to the call](https://skype.visualstudio.com/SPOOL/_deliveryplans/plan/afec522a-2dee-4dc2-a6e6-8873cabda33b?System.AssignedTo=tinaharter%40microsoft.com)

* ...

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->