### PR TITLE
Sonasa/explicit consent

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -1052,6 +1052,20 @@ export default class CallCard extends React.Component {
                 console.log(`meetingAudioConferenceDetails MessageBarText = ${messageBarText}`)
                 this.setState({ callMessage: messageBarText })
             },
+            consentToBeingRecorded: async () => {
+                try {
+                    this.recordingFeature.consentToBeingRecordedAndTranscribed();
+                } catch(e) {
+                    console.error(e);
+                }
+            },
+            consentToBringTranscribed: async () => {
+                try {
+                    this.transcriptionFeature.consentToBeingRecordedAndTranscribed();
+                } catch(e) {
+                    console.error(e);
+                }
+            },
         }
     }
 
@@ -1107,6 +1121,31 @@ export default class CallCard extends React.Component {
                 onClick: (e) => menuCallBacks.stopSpotlight(this.identifier, e)
             });
         
+        this.recordingFeature.isConsentRequired && this.state.isRecordingActive && 
+        menuItems.push({
+            key: 'Provide consent to be Recorded',
+            text: 'Provide consent to be Recorded',
+            iconProps: { iconName: 'ReminderPerson'},
+            onClick: (e) => menuCallBacks.consentToBeingRecorded(e)
+        });
+
+        this.transcriptionFeature.isConsentRequired && this.state.isTranscriptionActive && menuItems.push({
+            key: 'Provide consent to be Transcribed',
+            text: 'Provide consent to be Transcribed',
+            iconProps: { iconName: 'ReminderPerson'},
+            onClick: (e) => menuCallBacks.consentToBeingTranscribed(this.identifier, e)
+        });
+
+        // Proactively provide consent for recording and transcription in the call if it is required
+        !this.state.isRecordingActive && !this.state.isTranscriptionActive && 
+        this.recordingFeature.isConsentRequired && this.transcriptionFeature.isConsentRequired &&
+        menuItems.push({
+            key: 'Provide consent to being Recorded and Transcribed',
+            text: 'Provide consent to being Recorded and Transcribed',
+            iconProps: { iconName: 'ReminderPerson'},
+            onClick: (e) => menuCallBacks.consentToBeingRecorded(e)
+        });
+
         return menuItems.filter(item => item != 0)
     }
 


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Update the sample app to show options for providing consent if the teams meeting/group call requires it.
* Consent can proactively be provided if the teams call has the configuration set.

![image](https://github.com/user-attachments/assets/8a9bbdd8-eb04-4aea-a05f-51deefc191d1)
![image](https://github.com/user-attachments/assets/677748a1-0e75-4733-b0d6-ab0957d743b2)
![image](https://github.com/user-attachments/assets/24bb7864-1d3b-4720-894f-9101f17d9325)
![image](https://github.com/user-attachments/assets/7bb2346b-72c2-49d9-9891-39cee77bcac7)


## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ ] No

The changes take dependency on the latest beta release : [releases/CL2024.R47](https://acs-rp.azurewebsites.net/public/releases/CL2024.R47/beta/1.32.1-beta.1/)
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[*] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code
*  Login as either ACS user Identity or Teams User Identity
*  Join the teams meeting where the organizer has policy: ExplicitRecordingConsent set (eg meeting Id: 243 306 063 424, meeting passcode: Et3iM2Bv)
* Start the recording/transcription, notice that user's mic, camera and screen share have been disabled.
* Unmute or turning video on will not work
* Use the menu drop down option to provide consent for recording/transcription
* Now user should be able to unmute / share screen and start the video for the call

```
git clone https://github.com/sonalisaxenacse12/communication-services-web-calling-tutorial
cd communication-services-web-calling-tutorial
git checkout sonasa/explicitConsent
npm install
```

updated the package source in the package.json
  "@azure/communication-calling": "<path to spool>/sdk/web/dist/skype-spool-sdk-1.0.0.tgz",

