### PR TITLE
Show edited display name

### DIFF
--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -1248,6 +1248,10 @@ export default class CallCard extends React.Component {
                 } catch(e) {
                     console.error(e);
                 }
+            },
+            handleDisplayNameChanged: async (newValue, oldValue, reason) => {
+                let messageBarText = `Display name updated: "${oldValue}" is now "${newValue}" because ${reason}`;
+                this.setState({ callMessage: messageBarText })
             }
         }
     }

--- a/Project/src/MakeCall/CallCard.js
+++ b/Project/src/MakeCall/CallCard.js
@@ -1250,7 +1250,7 @@ export default class CallCard extends React.Component {
                 }
             },
             handleDisplayNameChanged: async (newValue, oldValue, reason) => {
-                let messageBarText = `Display name updated: "${oldValue}" is now "${newValue}" because ${reason}`;
+                let messageBarText = `Display name changed from "${oldValue}" to "${newValue}" due to ${reason}`;
                 this.setState({ callMessage: messageBarText })
             }
         }

--- a/Project/src/MakeCall/RemoteParticipantCard.js
+++ b/Project/src/MakeCall/RemoteParticipantCard.js
@@ -31,7 +31,7 @@ export default class RemoteParticipantCard extends React.Component {
             state: this.remoteParticipant.state,
             isMuted: this.remoteParticipant.isMuted,
             hasDisplayNameChanged: this.remoteParticipant.hasDisplayNameChanged,
-            displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim(),
+            displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim(),
             participantIds: this.remoteParticipant.endpointDetails.map((e) => { return e.participantId }),
             isHandRaised: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.raiseHandFeature.getRaisedHands()),
             isSpotlighted: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.spotlightFeature.getSpotlightedParticipants()),
@@ -72,11 +72,14 @@ export default class RemoteParticipantCard extends React.Component {
         })
 
         this.remoteParticipant.on('displayNameChanged', ({newValue, oldValue, reason }) => {
+            const hasDisplayNameChanged = this.remoteParticipant.hasDisplayNameChanged;
+            const displayName = this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim();
             if (reason === 'editedDisplayName') {
                 console.log('Edited display Name: ', newValue, oldValue, reason);
-                this.setState({ hasDisplayNameChanged: this.remoteParticipant.hasDisplayNameChanged, displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim() })
+                this.setState({ hasDisplayNameChanged, displayName});
+                this.menuOptionsHandler.handleDisplayNameChanged(newValue, oldValue, reason);
             } else {
-                this.setState({displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim()}) 
+                this.setState({displayName})
             }
         });
 

--- a/Project/src/MakeCall/RemoteParticipantCard.js
+++ b/Project/src/MakeCall/RemoteParticipantCard.js
@@ -30,7 +30,8 @@ export default class RemoteParticipantCard extends React.Component {
             isSpeaking: this.remoteParticipant.isSpeaking,
             state: this.remoteParticipant.state,
             isMuted: this.remoteParticipant.isMuted,
-            displayName: this.remoteParticipant.displayName?.trim(),
+            hasDisplayNameChanged: this.remoteParticipant.hasDisplayNameChanged,
+            displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim(),
             participantIds: this.remoteParticipant.endpointDetails.map((e) => { return e.participantId }),
             isHandRaised: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.raiseHandFeature.getRaisedHands()),
             isSpotlighted: utils.isParticipantHandRaised(this.remoteParticipant.identifier, this.spotlightFeature.getSpotlightedParticipants()),
@@ -70,8 +71,13 @@ export default class RemoteParticipantCard extends React.Component {
             this.setState({ isSpeaking: this.remoteParticipant.isSpeaking });
         })
 
-        this.remoteParticipant.on('displayNameChanged', () => {
-            this.setState({ displayName: this.remoteParticipant.displayName?.trim() });
+        this.remoteParticipant.on('displayNameChanged', ({newValue, oldValue, reason }) => {
+            if (reason === 'editedDisplayName') {
+                console.log('Edited display Name: ', newValue, oldValue, reason);
+                this.setState({ hasDisplayNameChanged: this.remoteParticipant.hasDisplayNameChanged, displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim() })
+            } else {
+                this.setState({displayName: this.remoteParticipant.hasDisplayNameChanged ? (this.remoteParticipant.displayName ? `${this.remoteParticipant.displayName?.trim()} (Edited)` :  '') : this.remoteParticipant.displayName?.trim()}) 
+            }
         });
 
         this.spotlightFeature.on("spotlightChanged", () => {


### PR DESCRIPTION
## Purpose

In Teams meeting, if Teams user edited display name, the edited display name needs to be shown in the RemoteParticipantCard component.

Before display name update:
![image](https://github.com/user-attachments/assets/37116a1c-71ab-4f9e-a038-bddefdbf8827)

After display name update:
![image](https://github.com/user-attachments/assets/d6b2283e-6eac-4224-a84f-b5efb1fa3fd4)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->